### PR TITLE
Update GitHub Action to Use SVN Credentials Instead of WordPress Credentials

### DIFF
--- a/.github/workflows/release_plugin_on_tag.yml
+++ b/.github/workflows/release_plugin_on_tag.yml
@@ -14,5 +14,5 @@ jobs:
         EXCLUDE_LIST: .github .gitignore .eslintignore phpunit.xml phpcs.xml tests README.md 
         SLUG: embed-google-drive
         ASSETS_DIR: wp-assets
-        WORDPRESS_PASSWORD: ${{ secrets.WORDPRESS_PASSWORD }}
-        WORDPRESS_USERNAME: ${{ secrets.WORDPRESS_USERNAME }}
+        WORDPRESS_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+        WORDPRESS_USERNAME: ${{ secrets.SVN_USERNAME }}


### PR DESCRIPTION
## PR Description

The purpose of this PR is to Update Github action credentials for automatic updates with SVN credentials instead of WordPress credentials. 

For Reference 
- https://github.com/10up/action-wordpress-plugin-deploy/blob/develop/examples/deploy-on-pushing-a-new-tag.yml
- https://github.com/rtCamp/nginx-helper/pull/388

